### PR TITLE
Fix Valvetask handling of non-PWM channels

### DIFF
--- a/src/quail/System.hpp
+++ b/src/quail/System.hpp
@@ -40,7 +40,7 @@ public:
     // PressureSensor PT5 =  PressureSensor("PT5", Ad7124::AIN4Input, RANGE_1000);
     LoadSensor LC1 = LoadSensor("LC1", Ad7124::AIN12Input);
     // LoadSensor LC2 = LoadSensor("LC2", Ad7124::AIN7Input);
-    ThermalSensor TS0 = ThermalSensor("TC0", Ad7124::AIN8Input); //samd51 # defines TC0-7 so don't use those
+    ThermalSensor TS1 = ThermalSensor("TC1", Ad7124::AIN8Input); //samd51 # defines TC0-7 so don't use those
 
     Sensor* sensors [4] = {
         &PT1,
@@ -50,7 +50,7 @@ public:
         // &PT5,
         &LC1,
         // &LC2,
-        &TS0
+        &TS1
     };
 
     StateData statedata = StateData(); //holds current state of sensors/SVs/ematches systems for output + control

--- a/src/quail/actuators/ValveTask.cpp
+++ b/src/quail/actuators/ValveTask.cpp
@@ -10,8 +10,8 @@ ValveTask::ValveTask(uint8_t priority, uint8_t valve_pin_start) : Task(priority,
     valves[3] = {"S4", REAL_SMALL, NORMALLY_CLOSED};
     valves[4] = {"S5", REAL_SMALL, NORMALLY_CLOSED};
     valves[5] = {"S6", P_SMALL, NORMALLY_CLOSED};
-    valves[6] = {"S7", ABORT, NORMALLY_CLOSED};
-    valves[7] = {"S8", ABORT, NORMALLY_CLOSED};
+    valves[6] = {"S7", ABORT, NORMALLY_CLOSED}; // Warning: These can't do PWM
+    valves[7] = {"S8", ABORT, NORMALLY_CLOSED}; // Warning: These can't do PWM
     for (uint8_t i = 0; i < NUM_SOLENOIDS; i++) {
         pinMode(valve_pin_start + i, OUTPUT);
     }

--- a/src/quail/actuators/ValveTask.cpp
+++ b/src/quail/actuators/ValveTask.cpp
@@ -9,7 +9,7 @@ ValveTask::ValveTask(uint8_t priority, uint8_t valve_pin_start) : Task(priority,
     valves[2] = {"S3", SMALL, NORMALLY_CLOSED};
     valves[3] = {"S4", REAL_SMALL, NORMALLY_CLOSED};
     valves[4] = {"S5", REAL_SMALL, NORMALLY_CLOSED};
-    valves[5] = {"S6", REAL_SMALL, NORMALLY_CLOSED};
+    valves[5] = {"S6", P_SMALL, NORMALLY_CLOSED};
     valves[6] = {"S7", ABORT, NORMALLY_CLOSED};
     valves[7] = {"S8", ABORT, NORMALLY_CLOSED};
     for (uint8_t i = 0; i < NUM_SOLENOIDS; i++) {
@@ -23,13 +23,17 @@ void ValveTask::activity() {
         uint8_t valvestate = sys.statedata.getSolenoidState();
         for(uint8_t i = 0; i < NUM_SOLENOIDS; i++) {
             if((valvestate>>i & 0b1) == valves[i].normal) { // if valve is in the state in which it should be powered
-                if(valves[i].pwm)
+                if(digitalPinHasPWM(valve_pin_start + i))
                     analogWrite(valve_pin_start + i, valves[i].pwm);
                 else
                     digitalWrite(valve_pin_start + i, HIGH);
             }
-            else
-                digitalWrite(valve_pin_start + i, LOW);
+            else{
+                if(digitalPinHasPWM(valve_pin_start + i))
+                    analogWrite(valve_pin_start + i, 0);
+                else
+                    digitalWrite(valve_pin_start + i, LOW);
+            }
         }
     }
 }

--- a/src/quail/actuators/ValveTask.hpp
+++ b/src/quail/actuators/ValveTask.hpp
@@ -25,7 +25,7 @@ typedef enum {
     SMALL = 130,
     MEDIUM = 220, // Edelbrook
     LARGE = 180, // Pro BigShot
-    ABORT = 0 // don't pwm, just digital write
+    ABORT = 255 // don't pwm, just digital write
 } solenoid_pwm_t; // making solenoid pwm values more readable, values taken from old quail
 
 typedef struct {

--- a/src/quail/rx_tx_log/LoggerTask.cpp
+++ b/src/quail/rx_tx_log/LoggerTask.cpp
@@ -118,13 +118,13 @@ void LoggerTask::writeSD(char *buf) {
     if (res != FR_OK) {
         loggingEnabled = false;
         digitalWrite(DISK_LED, false);
-        sys.tasks.logger.log("SD Write Error");
+        this->log("SD Write Error");
     }
 
     res = f_sync(&file_object); //update file structure
     if (res != FR_OK) {
         loggingEnabled = false;
         digitalWrite(DISK_LED, false);
-        sys.tasks.logger.log("SD Flush Error");
+        this->log("SD Flush Error");
     }
 }

--- a/src/quail/sensors/PressureSensor.cpp
+++ b/src/quail/sensors/PressureSensor.cpp
@@ -9,7 +9,7 @@ PressureSensor::PressureSensor(const char* ch_name, Ad7124::InputSel ainp, Press
 void PressureSensor::configure() {
     if(cfg == UNCONFIGURED) { // cfg is static - once one sensor of a type is set up, this loop won't run
         cfg = add_config();
-        sys.adc.setConfig(cfg, Ad7124::RefAVdd, Ad7124::Pga1, false);
+        sys.adc.setConfig(cfg, Ad7124::RefIn2, Ad7124::Pga1, false);
         sys.adc.setConfigFilter(cfg, Ad7124::Sinc3Filter, 512);
     }
     sys.adc.setChannel(ch_id, cfg, ainp, ainm, true);
@@ -18,7 +18,7 @@ void PressureSensor::configure() {
 
 float PressureSensor::convertToFloat(uint32_t adc_dataword)
 {
-    float voltage = Ad7124Chip::toVoltage(adc_dataword, 1, 3.6, false);
+    float voltage = Ad7124Chip::toVoltage(adc_dataword, 1, 2.5, false);
     voltage = voltage * 1.5;
     //TODO: make this calculation variable based on range, set by this->range
     float pressure = (voltage - 0.5) / 4.0 * (range*PSI_TO_PA);

--- a/src/quail/sensors/ThermalSensor.cpp
+++ b/src/quail/sensors/ThermalSensor.cpp
@@ -8,7 +8,7 @@ ThermalSensor::ThermalSensor(const char* ch_name, Ad7124::InputSel ainp) :
 void ThermalSensor::configure() {
     if(cfg == UNCONFIGURED) { // cfg is static - once one sensor of a type is set up, this loop won't run
         cfg = add_config();
-        sys.adc.setConfig(cfg, Ad7124::RefAVdd, Ad7124::Pga1, false);
+        sys.adc.setConfig(cfg, Ad7124::RefAVdd, Ad7124::Pga1, true);
         sys.adc.setConfigFilter(cfg, Ad7124::Sinc3Filter, 1);
     }
     sys.adc.setChannel(ch_id, cfg, ainp, ainm, true);
@@ -17,9 +17,8 @@ void ThermalSensor::configure() {
 
 float ThermalSensor::convertToFloat(uint32_t adc_dataword)
 {
-    float voltage = Ad7124Chip::toVoltage(adc_dataword, 1, 2.5, false);
-    voltage = voltage * 2;
+    float voltage = Ad7124Chip::toVoltage(adc_dataword, 1, 3.6, true);
     //TODO: make this calculation variable based on range, set by this->range
-    float temp = (voltage);
+    float temp = (voltage * 200.0); // 5mV/degC
     return temp;
 };


### PR DESCRIPTION
I know you just fixed this, but I think this is cleaner. ABORT setting works on PWM channels too.